### PR TITLE
Automatically open repository if one already exists when using `Open with Visual Studio`

### DIFF
--- a/develop.cmd
+++ b/develop.cmd
@@ -2,4 +2,4 @@
 
 @echo Visual Studio will use live builds of 'GitHub.VisualStudio.Contrib.dll'
 set GitHub_VisualStudio_Contrib_Path=%cd%\src\GitHub.VisualStudio.Contrib\obj\Debug\GitHub.VisualStudio.Contrib.dll
-start devenv.exe "%SolutionFile%"
+start devenv.exe "%SolutionFile%" %*

--- a/install.cmd
+++ b/install.cmd
@@ -1,3 +1,5 @@
 @call "vars.bat"
 
-vsixutil /install "%VsixPath%" /v 15 /s Enterprise;Professional;Community
+vsixutil /install "%VsixPath%" /v 15 /s Enterprise
+vsixutil /install "%VsixPath%" /v 15 /s Professional
+vsixutil /install "%VsixPath%" /v 15 /s Community

--- a/src/GitHub.VisualStudio.Contrib.Vsix/GitHubCommandPackage.cs
+++ b/src/GitHub.VisualStudio.Contrib.Vsix/GitHubCommandPackage.cs
@@ -42,9 +42,9 @@ namespace GitHub.VisualStudio.Contrib.Vsix
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(GitHubCommandPackage.PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
+    [ProvideAppCommandLine("GitClone", typeof(GitHubCommandPackage), Arguments = "1", DemandLoad = 1)]
     public sealed class GitHubCommandPackage : Package, IOleCommandTarget
     {
-
         /// <summary>
         /// GitHubCommandPackage GUID string.
         /// </summary>

--- a/src/GitHub.VisualStudio.Contrib/Console/VSGitServicesSubcommands.cs
+++ b/src/GitHub.VisualStudio.Contrib/Console/VSGitServicesSubcommands.cs
@@ -33,5 +33,11 @@ namespace GitHub.VisualStudio.Contrib.Console
                 consoleContext.WriteLine($"{repo.CloneUrl} ({repo.LocalPath})");
             }
         }
+
+        [Export, SubcommandMetadata("GetLocalClonePathFromGitProvider")]
+        public void GetLocalClonePathFromGitProvider()
+        {
+            consoleContext.WriteLine(vsGitServices.GetLocalClonePathFromGitProvider());
+        }
     }
 }

--- a/src/GitHub.VisualStudio.Contrib/GitCloneCommandLine.cs
+++ b/src/GitHub.VisualStudio.Contrib/GitCloneCommandLine.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.IO;
+using System.Diagnostics;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using GitHub.Services;
+using GitHub.Primitives;
+
+namespace GitHub.VisualStudio.Contrib
+{
+    [Export]
+    public class GitCloneCommandLine
+    {
+        Package package;
+        IVSGitServices vsGitServices;
+        IVSServices vsServices;
+
+        [ImportingConstructor]
+        internal GitCloneCommandLine(Package package, IVSGitServices vsGitServices,
+            ITeamExplorerServices teamExplorerServices, IVSServices vsServices)
+        {
+            this.package = package;
+            this.vsGitServices = vsGitServices;
+            this.vsServices = vsServices;
+
+            var cloneUrl = FindCloneUrl();
+            if(cloneUrl == null)
+            {
+                return;
+            }
+
+            TryOpenRepository(cloneUrl);
+        }
+
+        bool TryOpenRepository(string cloneUrl)
+        {
+            return TryOpenKnownRepository(cloneUrl) || TryOpenLocalClonePath(cloneUrl);
+        }
+
+        bool TryOpenKnownRepository(string cloneUrl)
+        {
+            var repos = vsGitServices.GetKnownRepositories();
+            foreach (var repo in repos)
+            {
+                if (cloneUrl == repo.CloneUrl)
+                {
+                    if (Directory.Exists(repo.LocalPath))
+                    {
+                        if(vsServices.TryOpenRepository(repo.LocalPath))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        bool TryOpenLocalClonePath(string cloneUrl)
+        {
+            var cloneUri = FindGitHubCloneUri(cloneUrl);
+            if(cloneUri == null)
+            {
+                return false;
+            }
+
+            var clonePath = vsGitServices.GetLocalClonePathFromGitProvider();
+            var repoPath = Path.Combine(clonePath, cloneUri.Owner, cloneUri.RepositoryName);
+            if (!Directory.Exists(repoPath))
+            {
+                return false;
+            }
+
+            return vsServices.TryOpenRepository(repoPath);
+        }
+
+        static UriString FindGitHubCloneUri(string cloneUrl)
+        {
+            try
+            {
+                var uriString = new UriString(cloneUrl);
+                if (uriString.Host != "github.com")
+                {
+                    return null;
+                }
+
+                if(string.IsNullOrEmpty(uriString.Owner) || string.IsNullOrEmpty(uriString.RepositoryName))
+                {
+                    return null;
+                }
+
+                return uriString;
+            }
+            catch(Exception e)
+            {
+                Trace.WriteLine(e);
+                return null;
+            }
+        }
+
+        string FindCloneUrl()
+        {
+            var cmdline = (IVsAppCommandLine)ServiceProvider.GetService(typeof(SVsAppCommandLine));
+            cmdline.GetOption("GitClone", out int isPresent, out string optionValue);
+            if (isPresent == 0)
+            {
+                return null;
+            }
+
+            return optionValue;
+        }
+
+        IServiceProvider ServiceProvider => package;
+    }
+}

--- a/src/GitHub.VisualStudio.Contrib/GitHub.VisualStudio.Contrib.csproj
+++ b/src/GitHub.VisualStudio.Contrib/GitHub.VisualStudio.Contrib.csproj
@@ -147,6 +147,7 @@
   <ItemGroup>
     <Compile Include="CommandBase.cs" />
     <Compile Include="CommandIDAttribute.cs" />
+    <Compile Include="GitCloneCommandLine.cs" />
     <Compile Include="Console\SubcommandMetadataAttribute.cs" />
     <Compile Include="Console\ConsoleContext.cs" />
     <Compile Include="Console\ConsoleCommand.cs" />

--- a/src/GitHub.VisualStudio.Contrib/PackageLifecycle.cs
+++ b/src/GitHub.VisualStudio.Contrib/PackageLifecycle.cs
@@ -47,6 +47,7 @@
             container = new CompositionContainer(assemblyCatalog, sp.ExportProvider);
             container.ComposeExportedValue(package);
             container.GetExportedValues<CommandBase>();
+            container.GetExportedValue<GitCloneCommandLine>();
         }
 
         public void Dispose()


### PR DESCRIPTION
Check for a know repo with the target URL or for a directory relative to the default location. Of one exists, change the context giving user option to open rather than clone.