### PR TITLE
Spike of Open from GitHub functionality

### DIFF
--- a/src/GitHub.VisualStudio.Contrib/GitHubCommand.cs
+++ b/src/GitHub.VisualStudio.Contrib/GitHubCommand.cs
@@ -36,8 +36,6 @@ namespace GitHub.VisualStudio.Contrib
         async Task ShowOpenFromGitHubAsync()
         {
             var pane = await toolWindowManager.Value.ShowGitHubPane();
-            await pane.ShowPullRequests();
-
             if (pane.Content is INavigationViewModel navigationViewModel)
             {
                 var viewModel = factory.CreateViewModel<IHelloWorldViewModel>();

--- a/src/GitHub.VisualStudio.Contrib/UI/ViewModels/HelloWorldViewModel.cs
+++ b/src/GitHub.VisualStudio.Contrib/UI/ViewModels/HelloWorldViewModel.cs
@@ -14,7 +14,6 @@ namespace GitHub.VisualStudio.Contrib.UI.ViewModels
     {
         readonly IGitHubContextService contextService;
         readonly ITeamExplorerContext teamExplorerContext;
-        readonly IRepositoryCloneService repositoryCloneService;
 
         GitHubContext context;
         string targetUrl;
@@ -41,13 +40,15 @@ namespace GitHub.VisualStudio.Contrib.UI.ViewModels
                 contextService.TryOpenFile(localPath, Context);
             });
 
-            Clone = ReactiveCommand.Create();
+            Clone = ReactiveCommand.Create(this.WhenAnyValue(x =>
+                x.DefaultPath).Select(d => d is string dir && !Directory.Exists(d)));
             Clone.Subscribe(_ =>
             {
                 // await repositoryCloneService.CloneRepository(cloneUrl, repositoryDirName, targetDir);
             });
 
-            Open = ReactiveCommand.Create();
+            Open = ReactiveCommand.Create(this.WhenAnyValue(x =>
+                x.DefaultPath).Select(d => d is string dir && Directory.Exists(d)));
             Open.Subscribe(_ =>
             {
                 var dte = serviceProvider.GetService<EnvDTE.DTE>();

--- a/src/GitHub.VisualStudio.Contrib/UI/ViewModels/HelloWorldViewModel.cs
+++ b/src/GitHub.VisualStudio.Contrib/UI/ViewModels/HelloWorldViewModel.cs
@@ -33,7 +33,7 @@ namespace GitHub.VisualStudio.Contrib.UI.ViewModels
 
             Title = "GitHub URL";
 
-            GoTo = ReactiveCommand.Create();
+            GoTo = ReactiveCommand.Create(this.WhenAnyValue(x => x.BlobName).Select(b => b != null));
             GoTo.Subscribe(_ =>
             {
                 var localPath = teamExplorerContext.ActiveRepository?.LocalPath;

--- a/src/GitHub.VisualStudio.Contrib/UI/ViewModels/IHelloWorldViewModel.cs
+++ b/src/GitHub.VisualStudio.Contrib/UI/ViewModels/IHelloWorldViewModel.cs
@@ -1,4 +1,5 @@
-﻿using GitHub.ViewModels;
+﻿using GitHub.Services;
+using GitHub.ViewModels;
 using GitHub.ViewModels.Dialog;
 using GitHub.ViewModels.GitHubPane;
 using ReactiveUI;
@@ -7,6 +8,18 @@ namespace GitHub.VisualStudio.Contrib.UI.ViewModels
 {
     public interface IHelloWorldViewModel : IViewModel, IDialogContentViewModel, IPanePageViewModel, IOpenInBrowser
     {
-        IReactiveCommand<object> SayHello { get; }
+        IReactiveCommand<object> GoTo { get; }
+
+        IReactiveCommand<object> Clone { get; }
+
+        IReactiveCommand<object> Open { get; }
+
+        string TargetUrl { get; set; }
+
+        string BlobName { get; }
+
+        string DefaultPath { get; }
+
+        GitHubContext Context { get; }
     }
 }

--- a/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
+++ b/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
@@ -9,38 +9,53 @@
     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
     DataContext="{Binding ViewModel}"
     mc:Ignorable="d">
-    
-  <UserControl.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-      </ResourceDictionary.MergedDictionaries>
-    </ResourceDictionary>
-  </UserControl.Resources>
 
-  <DockPanel>
-    <StackPanel Margin="10" Orientation="Vertical">
-        <ui:OcticonImage Icon="mark_github"
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel>
+        <StackPanel Margin="10" Orientation="Vertical">
+            <ui:OcticonImage Icon="mark_github"
             Foreground="{DynamicResource GitHubVsWindowText}"
             Margin="0,5"
             Width="48"
             Height="48" />
-        <Label
+            <Label
             Foreground="{DynamicResource GitHubVsWindowText}"
             HorizontalAlignment="Center"
             FontSize="16"
-            Content="Look an Octocat!" />
-        <StackPanel
-            Margin="0,5"
-            HorizontalAlignment="Center"
-            Orientation="Horizontal">
-            <TextBlock
-                Margin="10,0"
-                HorizontalAlignment="Center">
-                <Hyperlink Command="{Binding SayHello}"><TextBlock Text="Say, Hello" /></Hyperlink>
-            </TextBlock>
+            Content="Open from GitHub" />
+            <TextBox Text="{Binding TargetUrl, UpdateSourceTrigger=PropertyChanged}" />
+            <StackPanel
+                Margin="0,5"
+                HorizontalAlignment="Center"
+                Orientation="Horizontal">
+                <TextBlock Margin="10,0" HorizontalAlignment="Center">
+                    <Hyperlink Command="{Binding GoTo}">Go To</Hyperlink> <TextBlock Text="{Binding BlobName}" />
+                </TextBlock>
+            </StackPanel>
+            <StackPanel
+                Margin="0,5"
+                HorizontalAlignment="Center"
+                Orientation="Horizontal">
+                <TextBlock Margin="10,0" HorizontalAlignment="Center">
+                    <Hyperlink Command="{Binding Clone}">Clone</Hyperlink> <TextBlock Text="{Binding DefaultPath}" />
+                </TextBlock>
+            </StackPanel>
+            <StackPanel
+                Margin="0,5"
+                HorizontalAlignment="Center"
+                Orientation="Horizontal">
+                <TextBlock Margin="10,0" HorizontalAlignment="Center">
+                    <Hyperlink Command="{Binding Open}">Open</Hyperlink> <TextBlock Text="{Binding DefaultPath}" />
+                </TextBlock>
+            </StackPanel>
         </StackPanel>
-    </StackPanel>
-  </DockPanel>
+    </DockPanel>
 </local:GenericHelloWorldView>

--- a/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
+++ b/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
@@ -41,6 +41,7 @@
                 </TextBlock>
             </StackPanel>
             <StackPanel
+                x:Name="ClonePanel"
                 Margin="0,5"
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">
@@ -49,6 +50,7 @@
                 </TextBlock>
             </StackPanel>
             <StackPanel
+                x:Name="OpenPanel"
                 Margin="0,5"
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">

--- a/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
+++ b/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml
@@ -33,6 +33,7 @@
             Content="Open from GitHub" />
             <TextBox Text="{Binding TargetUrl, UpdateSourceTrigger=PropertyChanged}" />
             <StackPanel
+                x:Name="GoToPanel"
                 Margin="0,5"
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">

--- a/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml.cs
+++ b/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml.cs
@@ -16,10 +16,15 @@ namespace GitHub.VisualStudio.Contrib.UI.Views
     {
         public HelloWorldView()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             this.WhenActivated(d =>
             {
+                this.WhenAnyObservable(x => x.ViewModel.Clone.CanExecuteObservable)
+                    .BindTo(this, x => x.ClonePanel.Visibility);
+
+                this.WhenAnyObservable(x => x.ViewModel.Open.CanExecuteObservable)
+                    .BindTo(this, x => x.OpenPanel.Visibility);
             });
         }
     }

--- a/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml.cs
+++ b/src/GitHub.VisualStudio.Contrib/UI/Views/HelloWorldView.xaml.cs
@@ -20,6 +20,9 @@ namespace GitHub.VisualStudio.Contrib.UI.Views
 
             this.WhenActivated(d =>
             {
+                this.WhenAnyObservable(x => x.ViewModel.GoTo.CanExecuteObservable)
+                    .BindTo(this, x => x.GoToPanel.Visibility);
+
                 this.WhenAnyObservable(x => x.ViewModel.Clone.CanExecuteObservable)
                     .BindTo(this, x => x.ClonePanel.Visibility);
 


### PR DESCRIPTION
Learning ReactiveUI and prototyping a ModelView/View for an Open from GitHub pane/dialog.

To activate, use Open from GitHub on the Tools menu:

![image](https://user-images.githubusercontent.com/11719160/43324047-0ef31e36-91ab-11e8-89df-7e465a1f8a29.png)

GitHub pane should change (known issue - this must start off in a PR list or PR view).

![image](https://user-images.githubusercontent.com/11719160/43323999-f6e44072-91aa-11e8-82ba-5651e912f9b3.png)

Paste in a blob or home URL from any repository.

![image](https://user-images.githubusercontent.com/11719160/43324266-9d780fe0-91ab-11e8-8350-1f3ef17bc777.png)

You will have the option to `Clone`, `Open` or `Go To` depending on context.

Here's a pre-compiled version:
[GitHub.VisualStudio.Contrib.zip](https://github.com/editor-tools/GitHub.VisualStudio.Contrib/files/2235960/GitHub.VisualStudio.Contrib.zip)
